### PR TITLE
Improve layout design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { FAQ } from '@/components/faq';
 import { Newsletter } from '@/components/newsletter';
 import { CTA } from '@/components/cta';
 import { Footer } from '@/components/footer';
+import { ScrollToTop } from '@/components/scroll-to-top';
 
 export default function Home() {
   return <div className="min-h-screen bg-gray-900 text-gray-50">
@@ -30,5 +31,6 @@ export default function Home() {
         <CTA />
       </main>
       <Footer />
+      <ScrollToTop />
     </div>;
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,7 +3,7 @@ import { Button } from './button';
 import { MenuIcon, XIcon } from 'lucide-react';
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  return <header className="bg-gray-900 border-b border-gray-800">
+  return <header className="sticky top-0 z-50 bg-gray-900/80 border-b border-gray-800 backdrop-blur-md">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center" data-aos="fade-up-left">

--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { ArrowUpIcon } from 'lucide-react';
+
+export function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setVisible(window.pageYOffset > 300);
+    };
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  if (!visible) return null;
+  return (
+    <button
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      className="fixed bottom-6 right-6 p-3 rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700 transition-colors"
+    >
+      <ArrowUpIcon className="w-5 h-5" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- make the header sticky with a backdrop blur
- add a ScrollToTop floating button component
- insert ScrollToTop on the home page

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688944a7296083288461b16714d13d2a